### PR TITLE
update react-chartjs-2 to fix biuld error about CommonJS unsupport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "@types/node": "^18.15.3",
         "@types/react": "^17.0.14",
         "babel-plugin-inline-react-svg": "^2.0.2",
-        "chart.js": "^3.7.0",
+        "chart.js": "^4.2.0",
         "eslint": "8.36.0",
         "eslint-config-next": "13.2.4",
         "react": "17.0.2",
-        "react-chartjs-2": "^5.0.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "17.0.2",
         "typescript": "^5.0.2"
       }
@@ -644,6 +644,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
       "dev": true
     },
     "node_modules/@mui/base": {
@@ -1802,10 +1808,16 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.0.tgz",
-      "integrity": "sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg==",
-      "dev": true
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "dev": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": "^7.0.0"
+      }
     },
     "node_modules/clsx": {
       "version": "1.1.1",
@@ -4297,12 +4309,12 @@
       }
     },
     "node_modules/react-chartjs-2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.0.0.tgz",
-      "integrity": "sha512-cA9dd1P4hHOfb4lpxaT6ghmfk3ZW0JgL94BpEf5sTTWFeeykNw3HgddcnTjFOikva9tLSnYTPE2b43cAUKZx5Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
       "dev": true,
       "peerDependencies": {
-        "chart.js": "^3.5.0 || ^4.0.0",
+        "chart.js": "^4.1.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
@@ -5511,6 +5523,12 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
+      "dev": true
+    },
     "@mui/base": {
       "version": "5.0.0-alpha.67",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.67.tgz",
@@ -6228,10 +6246,13 @@
       }
     },
     "chart.js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.7.0.tgz",
-      "integrity": "sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg==",
-      "dev": true
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "dev": true,
+      "requires": {
+        "@kurkle/color": "^0.3.0"
+      }
     },
     "clsx": {
       "version": "1.1.1",
@@ -8066,9 +8087,9 @@
       }
     },
     "react-chartjs-2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.0.0.tgz",
-      "integrity": "sha512-cA9dd1P4hHOfb4lpxaT6ghmfk3ZW0JgL94BpEf5sTTWFeeykNw3HgddcnTjFOikva9tLSnYTPE2b43cAUKZx5Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "@types/node": "^18.15.3",
     "@types/react": "^17.0.14",
     "babel-plugin-inline-react-svg": "^2.0.2",
-    "chart.js": "^3.7.0",
+    "chart.js": "^4.2.0",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",
     "react": "17.0.2",
-    "react-chartjs-2": "^5.0.0",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "17.0.2",
     "typescript": "^5.0.2"
   }


### PR DESCRIPTION
#6
v5.0.0へのアップデートでbuildができなくなった。
https://github.com/naitoNanaco/pages/actions/runs/4461229117/jobs/7834905445
CommonJSへのサポートがなくなりnamed exportがサポートされなくなったため。

v5.1からCommonJSが再サポートされるようになっているためバージョンを上げることで解決する。
https://react-chartjs-2.js.org/docs/migration-to-v5